### PR TITLE
Adding getCreditCard in profile page

### DIFF
--- a/src/presentation/pages/Profile/CreditCards/CreditCards.tsx
+++ b/src/presentation/pages/Profile/CreditCards/CreditCards.tsx
@@ -1,16 +1,13 @@
 import { Button, Grid, Typography } from '@material-ui/core';
 import { CreditCard, Delete } from '@material-ui/icons';
-import { useDeleteCreditCardMutation } from 'infrastructure/services/creditCard/CreditCardService';
-import { useAppDispatch, useAppSelector } from 'app/hooks/reduxHooks';
 import { setDefaultCreditCard } from 'app/store/features/creditCardSlice';
+import { useCreditCards } from './useCreditCards';
 import useTranslation from 'app/hooks/useTranslation';
 import styles from './CreditCards.module.scss';
 
 export const CreditCards = () => {
   const t = useTranslation();
-  const { creditCards, defaultCreditCard } = useAppSelector(state => state.creditCard);
-  const [deleteCreditCard] = useDeleteCreditCardMutation();
-  const dispatch = useAppDispatch();
+  const { creditCards, defaultCreditCard, dispatch, deleteCreditCard } = useCreditCards();
 
   return (
     <div className={styles.creditCards}>

--- a/src/presentation/pages/Profile/CreditCards/useCreditCards.ts
+++ b/src/presentation/pages/Profile/CreditCards/useCreditCards.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect } from 'react';
+import {
+  useDeleteCreditCardMutation,
+  useGetCreditCardsMutation,
+} from 'infrastructure/services/creditCard/CreditCardService';
+import { useAppDispatch, useAppSelector } from 'app/hooks/reduxHooks';
+
+export const useCreditCards = () => {
+  const [deleteCreditCard] = useDeleteCreditCardMutation();
+  const [getCreditCards] = useGetCreditCardsMutation();
+
+  const { creditCards, defaultCreditCard } = useAppSelector(state => state.creditCard);
+  const dispatch = useAppDispatch();
+
+  const loadData = useCallback(async () => await getCreditCards(), [getCreditCards]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  return {
+    creditCards,
+    defaultCreditCard,
+    dispatch,
+    deleteCreditCard,
+  };
+};


### PR DESCRIPTION
Description

- Adding getCreditCard call in profile page to cover complete credit card creation flow.
- Keeping logic in separate customHook

Reviewers:
@gastonri 

Screenshots: No visual changes