### PR TITLE
Feature/login status

### DIFF
--- a/src/app/interfaces/user/LoginStatus.ts
+++ b/src/app/interfaces/user/LoginStatus.ts
@@ -1,0 +1,104 @@
+export interface ILoginStatusResponse {
+  success: boolean;
+  result: Result;
+}
+
+export interface Result {
+  loggedIn: boolean;
+  account: Account;
+  user: User;
+  subaccount: null;
+  country: string;
+  state: string;
+  supportOnly: boolean;
+  mfaRequired: null;
+  requiresEmailLink: boolean;
+  mfa: null;
+  readOnly: boolean;
+  restrictedToSubaccount: boolean;
+  withdrawalEnabled: boolean;
+  internalTransfersEnabled: boolean;
+  onlyAllowSupportOnly: boolean;
+}
+
+export interface Account {
+  username: string;
+  collateral: number;
+  freeCollateral: number;
+  totalAccountValue: number;
+  totalPositionSize: number;
+  initialMarginRequirement: number;
+  maintenanceMarginRequirement: number;
+  marginFraction: null;
+  openMarginFraction: null;
+  liquidating: boolean;
+  backstopProvider: boolean;
+  positions: any[];
+  takerFee: number;
+  makerFee: number;
+  leverage: number;
+  positionLimit: null;
+  positionLimitUsed: null;
+  useFttCollateral: boolean;
+  chargeInterestOnNegativeUsd: boolean;
+  spotMarginEnabled: boolean;
+  spotLendingEnabled: boolean;
+}
+
+export interface User {
+  hkClientType: null;
+  agreedToTrumpExtension: null;
+  ukClientTypeResponse: null;
+  defaultFiat: null;
+  mobileHasTraded: null;
+  paidNftListingFee: null;
+  agreedToMarginAndLocAgreement: null;
+  mobileHasDeposited: null;
+  displayName: string;
+  email: string;
+  mid: string;
+  kycApplicationStatus: string;
+  kycLevel: number;
+  kycType: string;
+  referralCode: number;
+  referred: boolean;
+  referrerId: null;
+  vip: number;
+  mmLevel: number;
+  feeTier: number;
+  ftt: number;
+  jurisdiction: string;
+  monthlyVolume: number;
+  monthlyMakerVolume: number;
+  monthlyLtVolume: number;
+  monthlyLeveragedTokenCreationVolume: number;
+  monthlyLeveragedTokenRedemptionVolume: number;
+  dailyVolume: number;
+  dailyMakerVolume: number;
+  dailyLeveragedTokenCreationVolume: number;
+  dailyLeveragedTokenRedemptionVolume: number;
+  mfa: null;
+  requireMfaForWithdrawals: boolean;
+  requireWithdrawalPassword: boolean;
+  requireWhitelistedWithdrawals: boolean;
+  whitelistedAddressDelayDays: null;
+  randomSlug: string;
+  showInLeaderboard: boolean;
+  useRealNameInLeaderboard: boolean;
+  chatUserId: null;
+  useBodPriceChange: boolean;
+  confirmTrades: boolean;
+  cancelAllOrdersButtonEnabled: boolean;
+  passedLtQuiz: boolean;
+  ukClientType: string;
+  hkStatus: string;
+  hkStatusMobile: string;
+  nuveiUploadedPof: boolean;
+  neverRequireEmailLinks: boolean;
+  chatApp: null;
+  chatHandle: null;
+  language: null;
+  dailyLocInterestRate: number;
+  optionsEnabled: boolean;
+  canOtcTradeOptions: boolean;
+}

--- a/src/app/store/features/userSlice.ts
+++ b/src/app/store/features/userSlice.ts
@@ -13,6 +13,7 @@ import {
   signupFulfiled,
   signupFTXFulfiled,
   loginFTXFulfiled,
+  loginStatusFulfiled,
 } from 'infrastructure/services/user/UserService';
 
 const initialState: UserState = {
@@ -72,6 +73,19 @@ const userSlice = createSlice({
         }
       ) => {
         state.tokenFtx = token;
+      }
+    );
+    builder.addMatcher(
+      loginStatusFulfiled,
+      (
+        state,
+        {
+          payload: {
+            result: { user },
+          },
+        }
+      ) => {
+        state.user.kyc1ed = Boolean(user.kycLevel);
       }
     );
     builder.addMatcher(logoutFulfiled, state => (state = initialState));

--- a/src/infrastructure/services/user/UserService.ts
+++ b/src/infrastructure/services/user/UserService.ts
@@ -1,5 +1,6 @@
 import { endpoints } from 'app/constants/endpoints';
 import { Country } from 'app/interfaces/common/Country';
+import { ILoginStatusResponse } from 'app/interfaces/user/LoginStatus';
 import { api } from '../Api';
 
 const authApi = api.injectEndpoints({
@@ -21,6 +22,14 @@ const authApi = api.injectEndpoints({
           captcha: {
             recaptcha_challenge: user.recaptcha,
           },
+        },
+      }),
+    }),
+    loginStatus: builder.mutation<ILoginStatusResponse, void>({
+      query: () => ({
+        url: `${process.env.REACT_APP_FTX_API_URL}/login_status`,
+        headers: {
+          ftxAuthorization: 'yes',
         },
       }),
     }),
@@ -120,6 +129,7 @@ interface signupFTXBody {
 export const {
   useLoginMutation,
   useLoginFTXMutation,
+  useLoginStatusMutation,
   useLogoutMutation,
   useSignupMutation,
   useSignupFTXMutation,
@@ -129,6 +139,7 @@ export const {
     signup: { matchFulfilled: signupFulfiled },
     login: { matchFulfilled: loginFulfiled },
     logout: { matchFulfilled: logoutFulfiled, matchRejected: logoutRejected },
+    loginStatus: { matchFulfilled: loginStatusFulfiled },
     signupFTX: { matchFulfilled: signupFTXFulfiled },
     loginFTX: { matchFulfilled: loginFTXFulfiled },
     kyc: { matchFulfilled: kycFulfiled, matchRejected: kycRejected },

--- a/src/presentation/components/Login/useLogin.ts
+++ b/src/presentation/components/Login/useLogin.ts
@@ -1,4 +1,8 @@
-import { useLoginMutation, useLoginFTXMutation } from 'infrastructure/services/user/UserService';
+import {
+  useLoginMutation,
+  useLoginFTXMutation,
+  useLoginStatusMutation,
+} from 'infrastructure/services/user/UserService';
 import { useEffect, useContext, useState } from 'react';
 import { ModalContext } from 'app/context/ModalContext';
 import { useForm, SubmitHandler } from 'react-hook-form';
@@ -20,6 +24,7 @@ export const useLogin = () => {
   const { getToken } = useReCaptcha();
   const [login, { isLoading, isSuccess: loginSuccess }] = useLoginMutation();
   const [loginFTX, { error: signinError, isSuccess, isError }] = useLoginFTXMutation();
+  const [loginStatus] = useLoginStatusMutation();
   const [getCreditCards] = useGetCreditCardsMutation();
   const [getBalance] = useGetBalanceMutation();
   const { loginModalIsOpen, setLoginModalIsOpen, setSignupModalIsOpen } = useContext(ModalContext);
@@ -44,6 +49,7 @@ export const useLogin = () => {
 
     setUserInfo(data);
     await loginFTX({ ...data, recaptcha: token });
+    await loginStatus();
   };
 
   const handleClose = () => {


### PR DESCRIPTION
**Description**
We need to know if a user submitted KYC data from our site or from FTX site. Prior to this PR, the KYC were stored in our DB. In that scenario, we couldn't know if the user had KYC from FTX.
With this PR, we're getting rid of the call to our backend and implementing a new call to know this from FTX directly. This is stored in our SSOT and the application works the same as before.

- Adding new interface for the response from FTX.
- Implementing new mutation for Login status endpoint and state management on userSlice.
- Using the new implementation on login flow.

There is no visual change on the app.