### PR TITLE
Adding profile page for creaturechronicles domain

### DIFF
--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import NFTPage from 'presentation/pages/NFT/NFTPage';
 import HomePage from 'presentation/pages/Home/HomePage';
 import MyCollection from 'presentation/pages/Profile/MyCollection';
@@ -15,6 +14,11 @@ export const routes = {
       component: <CreaturesPage />,
       exact: true,
       private: false,
+    },
+    {
+      path: routesPaths.profile,
+      component: <ProfilePage />,
+      private: true,
     },
   ],
   isNormalUser: [


### PR DESCRIPTION
**Description**
Profile page is not working right now when the user goes through creaturechronicles.io. 
In this PR, we're adding that route when the user comes from creaturechronicles, so they can see their profile.

Reviewers:
@Alejoboga20 @natokra @kevin-rodriguez @ImanolH96 

