### PR TITLE
Removing setting isAuth with internal login

### DIFF
--- a/src/app/store/features/userSlice.ts
+++ b/src/app/store/features/userSlice.ts
@@ -59,7 +59,6 @@ const userSlice = createSlice({
       }
     );
     builder.addMatcher(loginFulfiled, (state, { payload: { token, user } }) => {
-      state.isAuthenticated = true;
       state.token = token;
       state.user = { ...user };
     });


### PR DESCRIPTION
Removing setting isAuth with internal login
Avoid showing authenticated views when user is not logged in yet

Screenshots:
No visual Changes