### PR TITLE
Adding loading spinner and disabling buy creature button

### DIFF
--- a/src/presentation/components/BuyNowButton/BuyNowButton.tsx
+++ b/src/presentation/components/BuyNowButton/BuyNowButton.tsx
@@ -21,6 +21,7 @@ export const BuyNowButton = () => {
     fee,
     isOpen,
     isLoadingData,
+    isLoadingBuyNFT,
     depositModalIsOpen,
     handleClose,
     handleCloseDepositModal,
@@ -33,10 +34,14 @@ export const BuyNowButton = () => {
         <>
           {enoughBalance ? (
             <div className={styles.buyNowButton}>
-              <Button onClick={buyNft} variant="outlined">
-                <Typography variant="h6" component="p">
-                  {t('creatures.buyCreatures.buyButton')}
-                </Typography>
+              <Button onClick={buyNft} variant="outlined" disabled={isLoadingBuyNFT}>
+                {isLoadingBuyNFT ? (
+                  <CustomLoader color={colors.orangeCreatures} height={30} width={30} />
+                ) : (
+                  <Typography variant="h6" component="p">
+                    {t('creatures.buyCreatures.buyButton')}
+                  </Typography>
+                )}
               </Button>
             </div>
           ) : (

--- a/src/presentation/components/BuyNowButton/useBuyNowButton.ts
+++ b/src/presentation/components/BuyNowButton/useBuyNowButton.ts
@@ -24,7 +24,7 @@ export const useBuyNowButton = () => {
 
   const { setKycModalIsOpen, setCcModalIsOpen } = useContext(ModalContext);
 
-  const [buyNft, { isSuccess }] = useBuyNftByPackMutation();
+  const [buyNft, { isSuccess, isLoading: isLoadingBuyNFT }] = useBuyNftByPackMutation();
   const [getPackInfo] = useGetNftPackInfoMutation();
   const [getCreditCardFees] = useGetCreditCardFeesMutation();
   const [getBalance] = useGetBalanceMutation();
@@ -91,6 +91,7 @@ export const useBuyNowButton = () => {
     enoughBalance,
     fee,
     isLoadingData,
+    isLoadingBuyNFT,
     depositModalIsOpen,
     isOpen,
     handleClose,


### PR DESCRIPTION
**Description:**
Currently, we are not showing visual change for the user to know that a buy process started. So we are adding a spinner and disabling the buy now button. This will prevent that the user buy more than one creature incorrectly and will provide visual feedback for them to know what's going on.

**Reviewers:**
@natokra @kevin-rodriguez @ImanolH96 @Alejoboga20 

**Screenshot:**
![image](https://user-images.githubusercontent.com/24862956/148541502-147d8871-0caa-414d-ab77-2047e2e2365e.png)
