### PR TITLE
Separating checkboxes component from login and signup

### DIFF
--- a/src/app/context/ModalContext.tsx
+++ b/src/app/context/ModalContext.tsx
@@ -11,6 +11,8 @@ const initialState: ModalContextState = {
   setCcModalIsOpen: () => {},
   creditCardModalIsOpen: false,
   setCreditCardModalIsOpen: () => {},
+  checkboxesModalIsOpen: false,
+  setCheckboxesModalIsOpen: () => {},
 };
 
 export const ModalContext = createContext(initialState);
@@ -25,6 +27,7 @@ export const ModalProvider = ({ children }: ModalProviderProps) => {
   const [kycModalIsOpen, setKycModalIsOpen] = useState<boolean>(false);
   const [ccModalIsOpen, setCcModalIsOpen] = useState<boolean>(false);
   const [creditCardModalIsOpen, setCreditCardModalIsOpen] = useState<boolean>(false);
+  const [checkboxesModalIsOpen, setCheckboxesModalIsOpen] = useState<boolean>(false);
 
   return (
     <ModalContext.Provider
@@ -39,6 +42,8 @@ export const ModalProvider = ({ children }: ModalProviderProps) => {
         setCcModalIsOpen,
         creditCardModalIsOpen,
         setCreditCardModalIsOpen,
+        checkboxesModalIsOpen,
+        setCheckboxesModalIsOpen,
       }}
     >
       {children}
@@ -57,4 +62,6 @@ interface ModalContextState {
   setCcModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   creditCardModalIsOpen: boolean;
   setCreditCardModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  checkboxesModalIsOpen: boolean;
+  setCheckboxesModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/src/app/store/features/userSlice.ts
+++ b/src/app/store/features/userSlice.ts
@@ -60,7 +60,7 @@ const userSlice = createSlice({
     );
     builder.addMatcher(loginFulfiled, (state, { payload: { token, user } }) => {
       state.token = token;
-      state.user = { ...user };
+      state.user = { ...state.user, ...user };
     });
     builder.addMatcher(
       loginFTXFulfiled,
@@ -97,6 +97,7 @@ const userSlice = createSlice({
     });
     builder.addMatcher(loginMfaFulfilled, (state, { payload }) => {
       state.tokenFtx = payload.result.token;
+      state.user.kyc1ed = payload.result.target.kycLevel && Boolean(payload.result.target.kycLevel);
     });
   },
 });

--- a/src/app/store/features/userSlice.ts
+++ b/src/app/store/features/userSlice.ts
@@ -79,7 +79,13 @@ const userSlice = createSlice({
       state.isAuthenticated = payload.loggedIn;
       state.user.kyc1ed = payload.user?.kycLevel && Boolean(payload.user.kycLevel);
     });
-    builder.addMatcher(logoutFulfiled, state => (state = initialState));
+    builder.addMatcher(logoutFulfiled, state => {
+      state.isAuthenticated = false;
+      state.tokenFtx = '';
+      state.token = '';
+      state.user = { ...initialState.user };
+      localStorage.clear();
+    });
     builder.addMatcher(logoutRejected, (state, { payload: { status } }) => {
       ErrorReqHandler({ status });
     });

--- a/src/infrastructure/components/Layout/TopBarLayout.tsx
+++ b/src/infrastructure/components/Layout/TopBarLayout.tsx
@@ -8,6 +8,7 @@ import { BackgroundLayout } from './BackgroundLayout';
 import { CC } from 'presentation/components/CC/CC';
 import { KYC } from 'presentation/components/KYC/KYC';
 import { useLoginStatusMutation } from 'infrastructure/services/user/UserService';
+import { Checkboxes } from 'presentation/components/Checkboxes/Checkboxes';
 
 interface TopBarLayoutProps {
   pageComponent: ReactElement;
@@ -30,6 +31,7 @@ export const TopBarLayout = ({ pageComponent, isTopBarVisible = true }: TopBarLa
       {pageComponent}
       <Login />
       <Signup />
+      <Checkboxes />
       <CreditCardModal />
       <CC />
       <KYC />

--- a/src/presentation/components/Checkboxes/Checkboxes.tsx
+++ b/src/presentation/components/Checkboxes/Checkboxes.tsx
@@ -7,8 +7,7 @@ import styles from './Checkboxes.module.scss';
 
 export const Checkboxes = ({ error }: CheckboxesProps) => {
   const t = useTranslation();
-  const { kyc1ed, isWalletReady, handleOnClick, isLoading, checkboxesModalIsOpen, handleClose } =
-    useCheckboxes();
+  const { kyc1ed, handleOnClick, isLoading, checkboxesModalIsOpen, handleClose } = useCheckboxes();
 
   return (
     <BaseModal open={checkboxesModalIsOpen} handleClose={handleClose}>
@@ -48,7 +47,7 @@ export const Checkboxes = ({ error }: CheckboxesProps) => {
             </div>
 
             <div className={styles.checkboxes__container}>
-              <Checkbox checked={isWalletReady} />
+              <Checkbox checked={false} />
               <Typography variant="h6" className={styles.checkboxes__containerText}>
                 {t('walletSetup.thirdCheck')}
               </Typography>

--- a/src/presentation/components/Checkboxes/Checkboxes.tsx
+++ b/src/presentation/components/Checkboxes/Checkboxes.tsx
@@ -1,77 +1,73 @@
-import { useEffect } from 'react';
 import { Button, Checkbox, Typography } from '@material-ui/core';
 import { useCheckboxes } from './useCheckboxes';
 import { CustomLoader } from 'infrastructure/components/CustomLoader/CustomLoader';
 import useTranslation from 'app/hooks/useTranslation';
+import { BaseModal } from 'infrastructure/components/Modal/Modal';
 import styles from './Checkboxes.module.scss';
 
-export const Checkboxes = ({ handleClose, error }: CheckboxesProps) => {
+export const Checkboxes = ({ error }: CheckboxesProps) => {
   const t = useTranslation();
-  const { kyc1ed, isWalletReady, handleOnClick, isLoading } = useCheckboxes();
-
-  useEffect(() => {
-    if (isWalletReady) {
-      handleClose();
-    }
-  }, [isWalletReady]);
+  const { kyc1ed, isWalletReady, handleOnClick, isLoading, checkboxesModalIsOpen, handleClose } =
+    useCheckboxes();
 
   return (
-    <div className={styles.checkboxes}>
-      {isLoading ? (
-        <div className={styles.checkboxes__spinner}>
-          <CustomLoader />
-        </div>
-      ) : (
-        <>
-          <div className={styles.checkboxes__title}>
-            <Typography gutterBottom variant="h4">
-              {t('walletSetup.title')}
-            </Typography>
-            <Typography gutterBottom variant="h5">
-              {t('walletSetup.subtitle')}
-            </Typography>
-            <Typography gutterBottom variant="h6">
-              {t('walletSetup.description')}
-            </Typography>
+    <BaseModal open={checkboxesModalIsOpen} handleClose={handleClose}>
+      <div className={styles.checkboxes}>
+        {isLoading ? (
+          <div className={styles.checkboxes__spinner}>
+            <CustomLoader />
           </div>
+        ) : (
+          <>
+            <div className={styles.checkboxes__title}>
+              <Typography gutterBottom variant="h4">
+                {t('walletSetup.title')}
+              </Typography>
+              <Typography gutterBottom variant="h5">
+                {t('walletSetup.subtitle')}
+              </Typography>
+              <Typography gutterBottom variant="h6">
+                {t('walletSetup.description')}
+              </Typography>
+            </div>
 
-          {error && <div>{error}</div>}
+            {error && <div>{error}</div>}
 
-          <div className={styles.checkboxes__container}>
-            <Checkbox checked />
-            <Typography variant="h6" className={styles.checkboxes__containerText}>
-              {t('walletSetup.firstCheck')}
+            <div className={styles.checkboxes__container}>
+              <Checkbox checked />
+              <Typography variant="h6" className={styles.checkboxes__containerText}>
+                {t('walletSetup.firstCheck')}
+              </Typography>
+            </div>
+
+            <div className={styles.checkboxes__container}>
+              <Checkbox checked={Boolean(kyc1ed)} />
+              <Typography variant="h6" className={styles.checkboxes__containerText}>
+                {t('walletSetup.secondCheck')}
+              </Typography>
+            </div>
+
+            <div className={styles.checkboxes__container}>
+              <Checkbox checked={isWalletReady} />
+              <Typography variant="h6" className={styles.checkboxes__containerText}>
+                {t('walletSetup.thirdCheck')}
+              </Typography>
+            </div>
+
+            <div className={styles.checkboxes__button}>
+              <Button onClick={handleOnClick}>{t('walletSetup.activate')}</Button>
+            </div>
+
+            <Typography variant="body1" onClick={handleClose} className={styles.checkboxes__remind}>
+              {t('walletSetup.remindMeLater')}
             </Typography>
-          </div>
-
-          <div className={styles.checkboxes__container}>
-            <Checkbox checked={Boolean(kyc1ed)} />
-            <Typography variant="h6" className={styles.checkboxes__containerText}>
-              {t('walletSetup.secondCheck')}
-            </Typography>
-          </div>
-
-          <div className={styles.checkboxes__container}>
-            <Checkbox checked={isWalletReady} />
-            <Typography variant="h6" className={styles.checkboxes__containerText}>
-              {t('walletSetup.thirdCheck')}
-            </Typography>
-          </div>
-
-          <div className={styles.checkboxes__button}>
-            <Button onClick={handleOnClick}>{t('walletSetup.activate')}</Button>
-          </div>
-
-          <Typography variant="body1" onClick={handleClose} className={styles.checkboxes__remind}>
-            {t('walletSetup.remindMeLater')}
-          </Typography>
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
+    </BaseModal>
   );
 };
 
 interface CheckboxesProps {
-  handleClose: () => void;
   error?: string;
 }

--- a/src/presentation/components/Checkboxes/useCheckboxes.ts
+++ b/src/presentation/components/Checkboxes/useCheckboxes.ts
@@ -27,7 +27,6 @@ export const useCheckboxes = () => {
 
   const loadUserData = useCallback(async () => {
     setIsLoading(true);
-    console.log('sarasa');
     try {
       await getCreditCards();
       await getBalance();

--- a/src/presentation/components/Checkboxes/useCheckboxes.ts
+++ b/src/presentation/components/Checkboxes/useCheckboxes.ts
@@ -6,7 +6,6 @@ import { useGetCreditCardsMutation } from 'infrastructure/services/creditCard/Cr
 
 export const useCheckboxes = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const [isWalletReady, setIsWalletReady] = useState(false);
 
   const { kyc1ed } = useAppSelector(state => state.user.user);
   const { defaultCreditCard } = useAppSelector(state => state.creditCard);
@@ -38,16 +37,19 @@ export const useCheckboxes = () => {
   }, [getCreditCards, getBalance]);
 
   useEffect(() => {
-    loadUserData();
-  }, [loadUserData]);
+    if (checkboxesModalIsOpen) {
+      loadUserData();
+    }
+  }, [loadUserData, checkboxesModalIsOpen]);
 
   useEffect(() => {
-    setIsWalletReady(defaultCreditCard.status === 'approved');
+    if (defaultCreditCard.status === 'approved') {
+      handleClose();
+    }
   }, [defaultCreditCard]);
 
   return {
     kyc1ed,
-    isWalletReady,
     handleOnClick,
     isLoading,
     handleClose,

--- a/src/presentation/components/Checkboxes/useCheckboxes.ts
+++ b/src/presentation/components/Checkboxes/useCheckboxes.ts
@@ -1,27 +1,33 @@
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useAppSelector } from 'app/hooks/reduxHooks';
-import { useLoginStatusMutation } from 'infrastructure/services/user/UserService';
 import { ModalContext } from 'app/context/ModalContext';
 import { useGetBalanceMutation } from 'infrastructure/services/deposit/DepositService';
 import { useGetCreditCardsMutation } from 'infrastructure/services/creditCard/CreditCardService';
 
 export const useCheckboxes = () => {
   const [isLoading, setIsLoading] = useState(false);
+  const [isWalletReady, setIsWalletReady] = useState(false);
+
   const { kyc1ed } = useAppSelector(state => state.user.user);
   const { defaultCreditCard } = useAppSelector(state => state.creditCard);
+
+  const { checkboxesModalIsOpen, setCheckboxesModalIsOpen } = useContext(ModalContext);
   const { setKycModalIsOpen, setCcModalIsOpen } = useContext(ModalContext);
+
   const [getCreditCards] = useGetCreditCardsMutation();
   const [getBalance] = useGetBalanceMutation();
-  const [loginStatus] = useLoginStatusMutation();
-
-  const isWalletReady = defaultCreditCard.status === 'approved';
 
   const handleOnClick = () => {
     kyc1ed ? setCcModalIsOpen(true) : setKycModalIsOpen(true);
   };
 
-  const loadUserData = async () => {
+  const handleClose = () => {
+    setCheckboxesModalIsOpen(false);
+  };
+
+  const loadUserData = useCallback(async () => {
     setIsLoading(true);
+    console.log('sarasa');
     try {
       await getCreditCards();
       await getBalance();
@@ -30,20 +36,22 @@ export const useCheckboxes = () => {
     } finally {
       setIsLoading(false);
     }
-  };
-
-  useEffect(() => {
-    loginStatus();
-  }, [kyc1ed]);
+  }, [getCreditCards, getBalance]);
 
   useEffect(() => {
     loadUserData();
-  }, []);
+  }, [loadUserData]);
+
+  useEffect(() => {
+    setIsWalletReady(defaultCreditCard.status === 'approved');
+  }, [defaultCreditCard]);
 
   return {
     kyc1ed,
     isWalletReady,
     handleOnClick,
     isLoading,
+    handleClose,
+    checkboxesModalIsOpen,
   };
 };

--- a/src/presentation/components/Login/Login.tsx
+++ b/src/presentation/components/Login/Login.tsx
@@ -5,7 +5,6 @@ import { useLogin } from './useLogin';
 import { Grid } from '@material-ui/core';
 import { CustomLoader } from 'infrastructure/components/CustomLoader/CustomLoader';
 import { ReactComponent as FTXLogo } from 'app/assets/ftxus_logo.svg';
-import { Checkboxes } from '../Checkboxes/Checkboxes';
 import { Mfa } from '../Mfa/Mfa';
 import useTranslation from '../../../app/hooks/useTranslation';
 import styles from './Login.module.scss';
@@ -22,17 +21,12 @@ export const Login = () => {
     onSubmit,
     errors,
     error,
-    isGetCreditCardsSuccess,
     isMfaRequired,
     setIsMfaRequired,
   } = useLogin();
 
-  const formToRender = isGetCreditCardsSuccess ? (
-    isMfaRequired ? (
-      <Mfa setIsMfaRequired={setIsMfaRequired} />
-    ) : (
-      <Checkboxes handleClose={handleClose} />
-    )
+  const formToRender = isMfaRequired ? (
+    <Mfa setIsMfaRequired={setIsMfaRequired} />
   ) : (
     <form className={styles.loginForm} onSubmit={handleSubmit(onSubmit)}>
       <div className={styles.loginForm__logo}>

--- a/src/presentation/components/Login/useLogin.ts
+++ b/src/presentation/components/Login/useLogin.ts
@@ -28,7 +28,7 @@ export const useLogin = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isMfaRequired, setIsMfaRequired] = useState(false);
 
-  const [login] = useLoginMutation();
+  const [login, { isSuccess: isLoginSuccess }] = useLoginMutation();
   const [loginFTX, { isSuccess: isLoginFTXSuccess, error: signinError, isError }] = useLoginFTXMutation();
   const [loginStatus, { isSuccess: isLoginStatusSuccess, data: loginStatusData }] = useLoginStatusMutation();
   const { loginModalIsOpen, setLoginModalIsOpen, setSignupModalIsOpen, setCheckboxesModalIsOpen } =
@@ -79,24 +79,25 @@ export const useLogin = () => {
 
   useEffect(() => {
     if (isLoginFTXSuccess) {
+      loginStatus();
       login(userInfo);
     }
-  }, [isLoginFTXSuccess, login, userInfo]);
+  }, [isLoginFTXSuccess, loginStatus, login, userInfo]);
 
   useEffect(() => {
-    if (isLoginStatusSuccess) {
+    if (isLoginStatusSuccess && isLoginSuccess && isLoginFTXSuccess) {
       const { mfaRequired } = loginStatusData;
 
       if (mfaRequired) {
         setIsMfaRequired(Boolean(mfaRequired));
+        reset();
       } else {
         setCheckboxesModalIsOpen(true);
-        handleClose();
+        setLoginModalIsOpen(false);
       }
-
       setIsLoading(false);
     }
-  }, [isLoginStatusSuccess, handleClose, loginStatusData, setCheckboxesModalIsOpen]);
+  }, [isLoginStatusSuccess, isLoginSuccess, isLoginFTXSuccess, loginStatusData]);
 
   useEffect(() => {
     if (isError) {

--- a/src/presentation/components/Login/useLogin.ts
+++ b/src/presentation/components/Login/useLogin.ts
@@ -4,16 +4,14 @@ import {
   useLoginStatusMutation,
   authApi,
 } from 'infrastructure/services/user/UserService';
-import { useEffect, useContext, useState } from 'react';
+import { useEffect, useContext, useState, useCallback } from 'react';
 import { ModalContext } from 'app/context/ModalContext';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { recaptchaActions } from 'app/constants/contants';
-import { useGetCreditCardsMutation } from 'infrastructure/services/creditCard/CreditCardService';
-import { useGetBalanceMutation } from 'infrastructure/services/deposit/DepositService';
 import { getToken } from 'app/helpers/GetToken';
-import { useAppDispatch, useAppSelector } from 'app/hooks/reduxHooks';
+import { useAppDispatch } from 'app/hooks/reduxHooks';
 import useTranslation from 'app/hooks/useTranslation';
 
 interface FormValues {
@@ -24,20 +22,17 @@ interface FormValues {
 export const useLogin = () => {
   const t = useTranslation();
   const dispatch = useAppDispatch();
-  const { defaultCreditCard } = useAppSelector(state => state.creditCard);
 
-  const [isWalletReady, setIsWalletReady] = useState(false);
   const [error, setError] = useState('');
   const [userInfo, setUserInfo] = useState<FormValues>();
   const [isLoading, setIsLoading] = useState(false);
   const [isMfaRequired, setIsMfaRequired] = useState(false);
 
-  const [login, { isSuccess: isLoginSuccess }] = useLoginMutation();
+  const [login] = useLoginMutation();
   const [loginFTX, { isSuccess: isLoginFTXSuccess, error: signinError, isError }] = useLoginFTXMutation();
   const [loginStatus, { isSuccess: isLoginStatusSuccess, data: loginStatusData }] = useLoginStatusMutation();
-  const [getCreditCards, { isSuccess: isGetCreditCardsSuccess }] = useGetCreditCardsMutation();
-  const [getBalance] = useGetBalanceMutation();
-  const { loginModalIsOpen, setLoginModalIsOpen, setSignupModalIsOpen } = useContext(ModalContext);
+  const { loginModalIsOpen, setLoginModalIsOpen, setSignupModalIsOpen, setCheckboxesModalIsOpen } =
+    useContext(ModalContext);
 
   const schema = z.object({
     email: z.string().email({ message: t('login.error.invalidEmail') }),
@@ -66,52 +61,42 @@ export const useLogin = () => {
     }
   };
 
-  const handleClose = () => {
+  const resetErrors = useCallback(() => dispatch(authApi.util.resetApiState()), [dispatch]);
+
+  const handleClose = useCallback(() => {
     reset();
     clearErrors();
     setError('');
     setLoginModalIsOpen(false);
+    setIsMfaRequired(false);
     resetErrors();
-  };
+  }, [clearErrors, reset, resetErrors, setLoginModalIsOpen]);
 
   const handleOpenSignupModal = () => {
     handleClose();
     setSignupModalIsOpen(true);
   };
 
-  const loadUserData = async () => {
-    setIsLoading(true);
-
-    try {
-      await getCreditCards();
-      await getBalance();
-    } catch (e: any) {
-      setIsLoading(false);
-
-      throw new Error(e);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   useEffect(() => {
     if (isLoginFTXSuccess) {
       login(userInfo);
     }
-  }, [isLoginFTXSuccess]);
+  }, [isLoginFTXSuccess, login, userInfo]);
 
   useEffect(() => {
     if (isLoginStatusSuccess) {
       const { mfaRequired } = loginStatusData;
-      setIsMfaRequired(Boolean(mfaRequired));
-    }
-  }, [isLoginStatusSuccess]);
 
-  useEffect(() => {
-    if (isLoginSuccess) {
-      loadUserData();
+      if (mfaRequired) {
+        setIsMfaRequired(Boolean(mfaRequired));
+      } else {
+        setCheckboxesModalIsOpen(true);
+        handleClose();
+      }
+
+      setIsLoading(false);
     }
-  }, [isLoginSuccess]);
+  }, [isLoginStatusSuccess, handleClose, loginStatusData, setCheckboxesModalIsOpen]);
 
   useEffect(() => {
     if (isError) {
@@ -120,21 +105,7 @@ export const useLogin = () => {
 
       setIsLoading(false);
     }
-  }, [isError]);
-
-  useEffect(() => {
-    if (isGetCreditCardsSuccess) {
-      setIsWalletReady(defaultCreditCard.status === 'approved');
-    }
-  }, [isGetCreditCardsSuccess]);
-
-  useEffect(() => {
-    if (isWalletReady) {
-      handleClose();
-    }
-  }, [isWalletReady]);
-
-  const resetErrors = () => dispatch(authApi.util.resetApiState());
+  }, [isError, signinError]);
 
   return {
     loginModalIsOpen,
@@ -146,7 +117,6 @@ export const useLogin = () => {
     onSubmit,
     errors,
     error,
-    isGetCreditCardsSuccess,
     isMfaRequired,
     setIsMfaRequired,
   };

--- a/src/presentation/components/Signup/Signup.tsx
+++ b/src/presentation/components/Signup/Signup.tsx
@@ -3,7 +3,6 @@ import { InputText } from '../../../infrastructure/components/InputText/InputTex
 import { BaseModal } from 'infrastructure/components/Modal/Modal';
 import { useSignup } from './useSignup';
 import { Grid } from '@material-ui/core';
-import { Checkboxes } from '../Checkboxes/Checkboxes';
 import { CustomLoader } from 'infrastructure/components/CustomLoader/CustomLoader';
 import { ReactComponent as FTXLogo } from 'app/assets/ftxus_logo.svg';
 import { dolphinServiceLinks } from 'app/constants/contants';
@@ -24,12 +23,9 @@ export const Signup = () => {
     isTosAgree,
     errors,
     error,
-    isSuccess,
   } = useSignup();
 
-  const formToRender = isSuccess ? (
-    <Checkboxes handleClose={handleClose} />
-  ) : (
+  const formToRender = (
     <form className={styles.signupForm} onSubmit={handleSubmit(onSubmit)}>
       <div className={styles.signupForm__logo}>
         <FTXLogo />


### PR DESCRIPTION
**Description**
Signup and Login components are getting tangled with all the business logic that are supporting. The solution is taking out from them Checkboxes component in a new modal that will manage the user info at the start beyond user information (i.e., balances and credit cards).

**Reviewers**
@natokra @Alejoboga20 @ImanolH96 @kevin-rodriguez 

There's no visual change in the app.