### PR TITLE
Moving credit cards endpoints to frontend

### DIFF
--- a/src/app/helpers/sortBy.ts
+++ b/src/app/helpers/sortBy.ts
@@ -1,0 +1,3 @@
+export const sortBy = (key: string) => {
+  return (a: any, b: any) => (a[key] > b[key] ? 1 : b[key] > a[key] ? -1 : 0);
+};

--- a/src/app/interfaces/creditCard/creditCard.ts
+++ b/src/app/interfaces/creditCard/creditCard.ts
@@ -1,3 +1,36 @@
+import { CIRCLE_FAILURE_CODES } from 'app/constants/contants';
+
+export type Status = 'approved' | 'pending' | 'rejected' | 'needsDepositVerification';
+export type DepositVerificationStatus =
+  | 'notStarted'
+  | 'pending'
+  | 'submissionFailed'
+  | 'awaitingVerification'
+  | 'successful'
+  | 'failed';
+
+export interface ICreditCardsResponse {
+  result: CreditCardData[];
+  success: boolean;
+}
+
+export interface ICreditCardResponse {
+  result: CreditCardData;
+  success: boolean;
+}
+
+export interface CreditCardData {
+  id: string;
+  name: string;
+  time: string;
+  billingInfo: Record<string, string>;
+  status: Status;
+  errorCode: string;
+  depositVerificationStatus: DepositVerificationStatus;
+  depositVerificationErrorCode: keyof typeof CIRCLE_FAILURE_CODES;
+  data: Record<string, string> | null;
+}
+
 export interface ICreditCardError {
   data: CreditCardError;
   status: number;

--- a/src/app/store/features/creditCardSlice.ts
+++ b/src/app/store/features/creditCardSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { CreditCardData } from 'app/interfaces/creditCard/creditCard';
 import {
-  CreditCardData,
   deleteCreditCardFulfiled,
   getCreditCardsFulfiled,
 } from 'infrastructure/services/creditCard/CreditCardService';

--- a/src/app/store/features/creditCardSlice.ts
+++ b/src/app/store/features/creditCardSlice.ts
@@ -44,8 +44,8 @@ const creditCardSlice = createSlice({
       state.defaultCreditCard =
         payload.length === 0 ? { ...initialState.defaultCreditCard } : { ...payload[0] };
     });
-    builder.addMatcher(deleteCreditCardFulfiled, (state, { payload }) => {
-      state.creditCards = state.creditCards.filter(creditCard => creditCard.id != payload.cardId);
+    builder.addMatcher(deleteCreditCardFulfiled, (state, { meta }) => {
+      state.creditCards = state.creditCards.filter(creditCard => creditCard.id !== meta.arg.originalArgs);
     });
   },
 });

--- a/src/infrastructure/services/creditCard/CreditCardService.ts
+++ b/src/infrastructure/services/creditCard/CreditCardService.ts
@@ -1,5 +1,10 @@
-import { CIRCLE_FAILURE_CODES } from 'app/constants/contants';
 import { endpoints } from 'app/constants/endpoints';
+import { sortBy } from 'app/helpers/sortBy';
+import {
+  CreditCardData,
+  ICreditCardsResponse,
+  ICreditCardResponse,
+} from 'app/interfaces/creditCard/creditCard';
 import { api } from '../Api';
 
 export const creditCardApi = api.injectEndpoints({
@@ -31,12 +36,20 @@ export const creditCardApi = api.injectEndpoints({
       }),
     }),
     getCreditCards: builder.mutation<CreditCardData[], void>({
-      query: () => `${endpoints.CREDIT_CARD}`,
-      transformResponse: (response: CreditCardData[]) => response,
+      query: () => ({
+        url: `${process.env.REACT_APP_FTX_API_URL}/cards`,
+        method: 'GET',
+        headers: { ftxAuthorization: 'yes' },
+      }),
+      transformResponse: (response: ICreditCardsResponse) => response.result.concat().sort(sortBy('status')),
     }),
     getCreditCardById: builder.mutation<CreditCardData, string>({
-      query: (id: string) => `${endpoints.CREDIT_CARD}/${id}`,
-      transformResponse: (response: CreditCardData) => response,
+      query: (id: string) => ({
+        url: `${process.env.REACT_APP_FTX_API_URL}/cards/${id}`,
+        method: 'GET',
+        headers: { ftxAuthorization: 'yes' },
+      }),
+      transformResponse: (response: ICreditCardResponse) => response.result,
     }),
     getCreditCardFees: builder.mutation<FeeResult, void>({
       query: () => `${process.env.REACT_APP_FTX_API_URL}/cards/fees`,
@@ -66,27 +79,6 @@ interface CreditCardBody {
   postalCode: string;
   publicKey: string;
   keyId: string;
-}
-
-type DepositVerificationStatus =
-  | 'notStarted'
-  | 'pending'
-  | 'submissionFailed'
-  | 'awaitingVerification'
-  | 'successful'
-  | 'failed';
-
-type Status = 'approved' | 'pending' | 'rejected' | 'needsDepositVerification';
-export interface CreditCardData {
-  id: string;
-  name: string;
-  time: string;
-  billingInfo: Record<string, string>;
-  status: Status;
-  errorCode: string;
-  depositVerificationStatus: DepositVerificationStatus;
-  depositVerificationErrorCode: keyof typeof CIRCLE_FAILURE_CODES;
-  data: Record<string, string> | null;
 }
 
 interface FeeResult {

--- a/src/infrastructure/services/creditCard/CreditCardService.ts
+++ b/src/infrastructure/services/creditCard/CreditCardService.ts
@@ -57,8 +57,9 @@ export const creditCardApi = api.injectEndpoints({
     }),
     deleteCreditCard: builder.mutation({
       query: (creditCardId: string) => ({
-        url: `${endpoints.CREDIT_CARD}/${creditCardId}`,
+        url: `${process.env.REACT_APP_FTX_API_URL}/cards/${creditCardId}`,
         method: 'DELETE',
+        headers: { ftxAuthorization: 'yes' },
       }),
     }),
   }),


### PR DESCRIPTION
**Description**
We're moving requests made by our backend to the frontend to simplify the transactions and because using the backend as a proxy is not needed any more.
This PR includes the endpoint for getting credit cards and for getting a specific credit card.

**Reviewers**
@natokra @Alejoboga20 @kevin-rodriguez @ImanolH96 