### PR TITLE
Fix/heroletes filter reset

### DIFF
--- a/src/app/components/CC/Form/useCreditCardForm.ts
+++ b/src/app/components/CC/Form/useCreditCardForm.ts
@@ -71,15 +71,15 @@ export const useCreditCardForm = () => {
     });
   };
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     reset();
     clearErrors();
-  };
+  }, [reset, clearErrors]);
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     const data: any = await getCountries('');
     setCountries(data.data);
-  };
+  }, [getCountries, setCountries]);
 
   const getStates = useCallback(
     async (country: string) => {
@@ -91,7 +91,7 @@ export const useCreditCardForm = () => {
 
   useEffect(() => {
     loadData();
-  }, []);
+  }, [loadData]);
 
   useEffect(() => {
     getStates(watch('country'));
@@ -101,7 +101,7 @@ export const useCreditCardForm = () => {
     if (isSuccess) {
       handleClose();
     }
-  }, [isSuccess]);
+  }, [isSuccess, handleClose]);
 
   useEffect(() => {
     if (isError) {

--- a/src/app/components/Select/InputSelect.tsx
+++ b/src/app/components/Select/InputSelect.tsx
@@ -1,31 +1,61 @@
 import { Select, Typography } from '@material-ui/core';
-import { FieldValues, UseFormRegister } from 'react-hook-form';
+import { ReactFragment } from 'react';
+import { Controller, FieldValues, UseFormRegister, Control } from 'react-hook-form';
 import styles from './InputSelect.module.scss';
 
-export const InputSelect = ({ className, label = '', name, error, register, children }: InputSelectProps) => {
+export const InputSelect = ({
+  className,
+  label = '',
+  name,
+  error,
+  register,
+  children,
+  control,
+}: InputSelectProps) => {
   return (
     <div className={className}>
       <Typography>{label}</Typography>
-      <Select
-        {...register(name)}
-        variant="outlined"
-        fullWidth
-        error={!!error}
-        color="secondary"
-        defaultValue=""
-      >
-        {children}
-      </Select>
+      {control ? (
+        <Controller
+          name={name}
+          control={control}
+          render={({ field: { ref, ...field } }) => (
+            <Select
+              {...field}
+              inputRef={ref}
+              variant="outlined"
+              fullWidth
+              error={!!error}
+              color="secondary"
+              defaultValue=""
+            >
+              {children}
+            </Select>
+          )}
+        />
+      ) : (
+        <Select
+          {...register(name)}
+          variant="outlined"
+          fullWidth
+          error={!!error}
+          color="secondary"
+          defaultValue=""
+        >
+          {children}
+        </Select>
+      )}
       <small className={styles.inputSelect__error}>{error?.message}</small>
     </div>
   );
 };
 
 interface InputSelectProps {
-  children: JSX.Element[];
+  children: ReactFragment | JSX.Element[];
   className: string;
   label?: string;
   name?: string;
   error?: { message: string };
-  register: UseFormRegister<FieldValues>;
+  register?: UseFormRegister<FieldValues>;
+  control?: Control<any>;
 }

--- a/src/app/pages/HeroletesMarketplace/AttributesFilter/AttributesFilter.tsx
+++ b/src/app/pages/HeroletesMarketplace/AttributesFilter/AttributesFilter.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import styles from './AttributesFilter.module.scss';
 
 export const AttributesFilters = () => {
-  const { register, handleSubmit, onSubmit, clearForm } = useAttributesFilter();
+  const { handleSubmit, onSubmit, clearForm, control } = useAttributesFilter();
 
   return (
     <div style={{ padding: '1rem', backgroundColor: '#161616', marginTop: '0.5rem' }}>
@@ -15,51 +15,54 @@ export const AttributesFilters = () => {
         <InputSelect
           className={styles.attributesFilter__select}
           label="Athlete"
-          register={register}
           name="athlete"
+          control={control}
         >
-          {attributes.athletes.map(athlete => (
-            <MenuItem key={athlete} value={athlete}>
-              {athlete}
-            </MenuItem>
-          ))}
+          {React.Children.toArray(
+            attributes.athletes.map(athlete => (
+              <MenuItem key={athlete} value={athlete}>
+                {athlete}
+              </MenuItem>
+            ))
+          )}
         </InputSelect>
-        <InputSelect
-          className={styles.attributesFilter__select}
-          label="Sport"
-          register={register}
-          name="sport"
-        >
-          {attributes.sports.map(sport => (
-            <MenuItem key={sport} value={sport}>
-              {sport}
-            </MenuItem>
-          ))}
+        <InputSelect className={styles.attributesFilter__select} label="Sport" name="sport" control={control}>
+          {React.Children.toArray(
+            attributes.sports.map(sport => (
+              <MenuItem key={sport} value={sport}>
+                {sport}
+              </MenuItem>
+            ))
+          )}
         </InputSelect>
-        <InputSelect className={styles.attributesFilter__select} label="Tier" register={register} name="tier">
-          {attributes.tiers.map(tier => (
-            <MenuItem key={tier} value={tier}>
-              {tier}
-            </MenuItem>
-          ))}
+        <InputSelect className={styles.attributesFilter__select} label="Tier" name="tier" control={control}>
+          {React.Children.toArray(
+            attributes.tiers.map(tier => (
+              <MenuItem key={tier} value={tier}>
+                {tier}
+              </MenuItem>
+            ))
+          )}
         </InputSelect>
         <InputSelect
           className={styles.attributesFilter__select}
           label="Background"
-          register={register}
           name="background"
+          control={control}
         >
-          {attributes.backgrounds.map(background => (
-            <MenuItem key={background} value={background}>
-              {background}
-            </MenuItem>
-          ))}
+          {React.Children.toArray(
+            attributes.backgrounds.map(background => (
+              <MenuItem key={background} value={background}>
+                {background}
+              </MenuItem>
+            ))
+          )}
         </InputSelect>
         <InputSelect
           className={styles.attributesFilter__select}
           label="Signed"
-          register={register}
           name="signed"
+          control={control}
         >
           <MenuItem value="Yes">Yes</MenuItem>
           <MenuItem value="No">No</MenuItem>

--- a/src/app/pages/HeroletesMarketplace/AttributesFilter/useAttributesFilter.ts
+++ b/src/app/pages/HeroletesMarketplace/AttributesFilter/useAttributesFilter.ts
@@ -12,6 +12,14 @@ interface FormValues {
   signed: string;
 }
 
+const defaultValues = {
+  athlete: '',
+  sport: '',
+  tier: '',
+  background: '',
+  signed: '',
+};
+
 export const useAttributesFilter = () => {
   const { setQueryParams } = useContext(NFTDetailsContext);
 
@@ -23,7 +31,10 @@ export const useAttributesFilter = () => {
     signed: z.string(),
   });
 
-  const { register, handleSubmit, reset } = useForm({ resolver: zodResolver(schema), mode: 'onTouched' });
+  const { register, handleSubmit, reset, control } = useForm({
+    defaultValues,
+    resolver: zodResolver(schema),
+  });
 
   const onSubmit: SubmitHandler<FormValues> = async form => {
     setQueryParams(currentValue => ({ ...currentValue, filters: form }));
@@ -39,5 +50,6 @@ export const useAttributesFilter = () => {
     register,
     handleSubmit,
     clearForm,
+    control,
   };
 };

--- a/src/app/pages/Profile/MyCollections/MyCollectionItem.tsx
+++ b/src/app/pages/Profile/MyCollections/MyCollectionItem.tsx
@@ -41,12 +41,12 @@ export const MyCollectionItem = ({ name, index }: MyCollectionItemProps) => {
           {nftAttributesFilteredByName.map(item => {
             const isNftInArray = !!nftsWithAttributes.find(
               ({ Athlete, Background, Collection, Signed, Sport, Tier }) =>
-                Athlete == item.Athlete &&
-                Background == item.Background &&
-                Collection == item.Collection &&
-                Signed == item.Signed &&
-                Sport == item.Sport &&
-                Tier == item.Tier
+                Athlete === item.Athlete &&
+                Background === item.Background &&
+                Collection === item.Collection &&
+                Signed === item.Signed &&
+                Sport === item.Sport &&
+                Tier === item.Tier
             );
 
             return (


### PR DESCRIPTION
**Description**
We couldn't reset heroletes filters. This was due to the fact that some material components doesn't behave as expected in the integration with React Hook Form. We switch inputSelect to be a controlled component (with a component provided by the form library). We kept the old inputSelect otherwise we will have to change every form component to be controlled.
Look and feel is the same as before, now the reset button on heroletes marketplace works.